### PR TITLE
evolution: Make PixelSetupWizard welcome string overlayable

### DIFF
--- a/rro_overlays/PixelSetupWizardOverlayEvolutionX/res/values/strings.xml
+++ b/rro_overlays/PixelSetupWizardOverlayEvolutionX/res/values/strings.xml
@@ -28,4 +28,5 @@
     <string name="setup_design_items_summary_font_family" translatable="false">google-sans-text</string>
     <string name="setup_design_items_title_font_family" translatable="false">google-sans</string>
     <string name="setup_design_layout_gravity" translatable="false">start</string>
+    <string name="bc_welcome_message">Welcome to your Pixel</string>
 </resources>


### PR DESCRIPTION
* This would help overlay the 'Welcome to your Pixel' text on first boot, and allow device specific customization to add a visual touch