### PR TITLE
rro_overlays: Don't disable Adaptive sleep forcily

### DIFF
--- a/rro_overlays/EvolutionXConfigOverlay/res/values/config.xml
+++ b/rro_overlays/EvolutionXConfigOverlay/res/values/config.xml
@@ -17,9 +17,6 @@
 */
 -->
 <resources>
-    <!-- Flag indicating whether we should enable the adaptive sleep.-->
-    <bool name="config_adaptive_sleep_available">false</bool>
-
     <!-- Name of a font family to use for body text. -->
     <string name="config_bodyFontFamily" translatable="false">google-sans-text</string>
 


### PR DESCRIPTION
* Pixel devices supports this feature.

The Google Pixel comes standard with Adaptive Sleep (Screen Attention), and since this ROM is based on the Pixel, I thought it should be utilized. I don't know why this feature had disabled, but considering that many people (including myself) are building this ROM for the Pixel, I believe this would be beneficial.
If enabling this causes battery drain, tell them to disable it.
Also this config in fwb are off by default, so I don't think there is much chance of mess.