### PR TITLE
config: Add BCR only for devices with telephony

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -300,7 +300,4 @@ $(call inherit-product, vendor/evolution/config/version.mk)
 # Pixel Framework
 $(call inherit-product-if-exists, vendor/pixel-framework/config.mk)
 
-# Call the BCR setup
-$(call inherit-product, vendor/bcr/bcr.mk)
-
 -include $(WORKSPACE)/build_env/image-auto-bits.mk

--- a/config/telephony.mk
+++ b/config/telephony.mk
@@ -14,6 +14,9 @@
 # limitations under the License.
 #
 
+# Call the BCR setup
+$(call inherit-product, vendor/bcr/bcr.mk)
+
 # Telephony
 IS_PHONE := true
 


### PR DESCRIPTION
Previously, BCR was added to common.mk, this leads to adding BCR in devices without telephony (eg. WiFi only tablets), so instead, add BCR to telephony.mk, as a device supporting telephony should only have this feature.

* Add Basic Call Recording (BCR) support only for devices that have telephony support

Signed-off-by: citrine <111177829+ci-r@users.noreply.github.com>